### PR TITLE
Ignore undefined properties for inserts and selects.

### DIFF
--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -227,7 +227,7 @@ class MysqlDaoQueryHelper {
             const uncleanValue = obj[property];
             const snakeCaseProperty = _.snakeCase(property);
 
-            if (_.includes(['string', 'number', 'boolean', 'undefined'], typeof(uncleanValue)) || uncleanValue === null) {
+            if (_.includes(['string', 'number', 'boolean'], typeof(uncleanValue)) || uncleanValue === null) {
                 // Escaping primitive values
                 const cleanValue = config.dontCleanMysqlFunctions ? this.cleanSpecial(uncleanValue) : this.clean(uncleanValue);
                 cleanValues[snakeCaseProperty] = cleanValue;

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -422,7 +422,7 @@ describe('MysqlDaoQueryHelper', function() {
             output.non_null_field.should.eql("'IS NOT NULL'");
         });
 
-        it('Convert undefined value to null', function() {
+        it('Ignore undefined values', function() {
             const someObj = {firstName: 'John', lastName: 'Doe'};
             const output = mysqlDaoQueryHelper._cleanAndMapValues({
                 firstName: someObj.firstName,
@@ -430,10 +430,10 @@ describe('MysqlDaoQueryHelper', function() {
                 password: someObj.password
             });
             Should.exist(output);
-            output.should.have.properties(['first_name','last_name','password']);
+            output.should.have.properties(['first_name','last_name']);
+            output.should.not.have.properties(['password']);
             output.first_name.should.eql("'John'");
             output.last_name.should.eql("'Doe'");
-            output.password.should.eql("NULL");
         });
 
     });
@@ -460,7 +460,7 @@ describe('MysqlDaoQueryHelper', function() {
             sqlString.should.eql("SELECT * FROM users WHERE (first_name = 'John') AND (last_name IS NULL)");
         });
 
-        it('Should generate good WHERE clause when input contains undefined value (assumes it means NULL)', function() {
+        it('Should generate good WHERE clause when input contains undefined value (ignores the key)', function() {
             const sqlObj = Squel.select().from('users');
 
             const someObj = {firstName: 'John'};
@@ -468,7 +468,7 @@ describe('MysqlDaoQueryHelper', function() {
 
             const sqlString = sqlObj.toString();
 
-            sqlString.should.eql("SELECT * FROM users WHERE (first_name = 'John') AND (last_name IS NULL)");
+            sqlString.should.eql("SELECT * FROM users WHERE (first_name = 'John')");
         });
 
         it('Should generate good WHERE clause when input contains special functions', function() {


### PR DESCRIPTION
Converting undefined to NULL had unintended consequences for creating using VOs when the mysql columns have DEFAULTs, such as date_added. IMO, the behavior should be to just ignore undefined keys. I feel 75-80% strongly about this.

@jonathan-fulton do you disagree?
