### PR TITLE
Added basic support for query objects.

### DIFF
--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -17,6 +17,13 @@ class MysqlDaoQueryHelper {
     constructor(tableName, cleanFunction) {
         this._tableName = tableName;
         this._clean = cleanFunction;
+        this._queryOperators = {
+            gt: '>',
+            gte: '>=',
+            lt: '<',
+            lte: '<=',
+            eq: '='
+        };
     }
 
     /**
@@ -235,7 +242,7 @@ class MysqlDaoQueryHelper {
                 //TODO: Handle timezones using a config setting?
                 const cleanValue = config.dontCleanMysqlFunctions ? this.cleanSpecial(uncleanValue) : this.clean(uncleanValue);
                 cleanValues[snakeCaseProperty] = cleanValue;
-            } else if (Array.isArray(uncleanValue)) {
+            } else if (_.isArray(uncleanValue)) {
                 // Escaping array values
                 const cleanValueArray = [];
                 uncleanValue.forEach(uncleanVal => {
@@ -247,7 +254,15 @@ class MysqlDaoQueryHelper {
                 if (cleanValueArray.length > 0) {
                     cleanValues[snakeCaseProperty] = cleanValueArray;
                 }
+            } else if (_.isObject(uncleanValue)) {
+                this._validateQueryObject(uncleanValue);
+                const cleanQueryObj = this._cleanAndMapValues(uncleanValue, config);
+                // Escape the values in the operator object
+                if (_.size(cleanQueryObj) > 0) {
+                    cleanValues[snakeCaseProperty] = cleanQueryObj;
+                }
             }
+
         });
 
         return cleanValues;
@@ -264,14 +279,41 @@ class MysqlDaoQueryHelper {
                 sqlObject = sqlObject.where(`${columnName} IS NULL`);
             } else if (cleanValue === 'IS NULL' || cleanValue === 'IS NOT NULL') {
                 sqlObject = sqlObject.where(`${columnName} ${cleanValue}`);
-            } else if (Array.isArray(cleanValue)) {
+            } else if (_.isArray(cleanValue)) {
                 const cleanValueList = cleanValue.join(',');
                 sqlObject = sqlObject.where(`${columnName} IN (${cleanValueList})`)
+            } else if (_.isObject(cleanValue)) {
+                sqlObject = sqlObject.where(this._queryObjectToSql(columnName, cleanValue));
             } else {
                 sqlObject = sqlObject.where(`${columnName} = ${cleanValue}`);
             }
         });
         return sqlObject;
+    }
+
+    _validateQueryObject(queryObj) {
+        // If the unclean value is a query object, it should be flat and be have only accepted operation keys (gt, lt, eq, ne)
+        const possibleKeys = _.keys(this._queryOperators);
+        const hasValidKeys = _.difference(_.keys(queryObj), possibleKeys).length === 0;
+        // const hasNestedQueryObjects = !!_.find(queryObj, (val, key) => _.isObject(val));
+        if (!hasValidKeys) {
+            throw new Error('Query objects must be comprised of the accepted operator keys: (' + possibleKeys.join(',') + ').')
+        }
+    }
+
+    //TODO: Handle OR case.
+    _queryObjectToSql(columnName, queryObj) {
+
+        let sql = '';
+        let i = 0;
+        _.each(queryObj, (value, operator) => {
+            if (i++ > 0) {
+                sql += ' AND ';
+            }
+            sql += `${columnName} ${this._queryOperators[operator]} ${value}`;
+        });
+
+        return sql;
     }
 }
 

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -22,7 +22,8 @@ class MysqlDaoQueryHelper {
             gte: '>=',
             lt: '<',
             lte: '<=',
-            eq: '='
+            eq: '=',
+            ne: '!='
         };
     }
 

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -149,6 +149,45 @@ describe('MysqlDaoQueryHelper', function() {
             sql.should.eql("SELECT * FROM users LIMIT 2 OFFSET 1");
         });
 
+        it('Should generate a SELECT statement with a query object and gt/lt', function() {
+            const sql = mysqlDaoQueryHelper.getAll({
+                dateAdded: {
+                    gt: new Date('1990-01-05T13:30:00Z'),
+                    lt: new Date('1990-01-10T13:30:00Z')
+                }
+            });
+            Should.exist(sql);
+
+            sql.should.eql("SELECT * FROM users WHERE (date_added > '1990-01-05 13:30:00.000' AND date_added < '1990-01-10 13:30:00.000')");
+        });
+
+        it('Should generate a SELECT statement with a query object and gte/lte', function() {
+            const sql = mysqlDaoQueryHelper.getAll({
+                id: {
+                    gte: 5,
+                    lte: 10
+                }
+            });
+            Should.exist(sql);
+
+            sql.should.eql("SELECT * FROM users WHERE (id >= 5 AND id <= 10)");
+        });
+
+        it('Should generate a SELECT statement with multiple query objects', function() {
+            const sql = mysqlDaoQueryHelper.getAll({
+                name: {
+                    eq: 'Chas'
+                },
+                dateAdded: {
+                    gt: new Date('1990-01-05T13:30:00Z'),
+                    lte: new Date('1990-01-10T13:30:00Z')
+                }
+            });
+            Should.exist(sql);
+
+            sql.should.eql("SELECT * FROM users WHERE (name = 'Chas') AND (date_added > '1990-01-05 13:30:00.000' AND date_added <= '1990-01-10 13:30:00.000')");
+        });
+
     });
 
     describe('getCount', function() {

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -178,6 +178,9 @@ describe('MysqlDaoQueryHelper', function() {
                 name: {
                     eq: 'Chas'
                 },
+                lastName: {
+                    ne: 'Fantastic'
+                },
                 id: {
                     gt: 2
                 },
@@ -188,7 +191,7 @@ describe('MysqlDaoQueryHelper', function() {
             });
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (name = 'Chas') AND (id > 2) AND (date_added > '1990-01-05 13:30:00.000' AND date_added <= '1990-01-10 13:30:00.000')");
+            sql.should.eql("SELECT * FROM users WHERE (name = 'Chas') AND (last_name != 'Fantastic') AND (id > 2) AND (date_added > '1990-01-05 13:30:00.000' AND date_added <= '1990-01-10 13:30:00.000')");
         });
 
     });

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -178,6 +178,9 @@ describe('MysqlDaoQueryHelper', function() {
                 name: {
                     eq: 'Chas'
                 },
+                id: {
+                    gt: 2
+                },
                 dateAdded: {
                     gt: new Date('1990-01-05T13:30:00Z'),
                     lte: new Date('1990-01-10T13:30:00Z')
@@ -185,7 +188,7 @@ describe('MysqlDaoQueryHelper', function() {
             });
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (name = 'Chas') AND (date_added > '1990-01-05 13:30:00.000' AND date_added <= '1990-01-10 13:30:00.000')");
+            sql.should.eql("SELECT * FROM users WHERE (name = 'Chas') AND (id > 2) AND (date_added > '1990-01-05 13:30:00.000' AND date_added <= '1990-01-10 13:30:00.000')");
         });
 
     });


### PR DESCRIPTION
The idea being you can create advanced query logic with nested query objects in the mysqlDaoQueryHelper:

```
const sql = mysqlDaoQueryHelper.getAll({
                name: {
                    eq: 'Chas'
                },
                id: {
                    gte: 2
                },
                dateAdded: {
                    gte: new Date('1990-01-05T13:30:00Z'),
                    lt: new Date('1990-01-10T13:30:00Z')
                }
            });
```