### PR TITLE
Bump package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,25 +22,25 @@
   },
   "homepage": "https://github.com/jonathan-fulton/hapiest-mysql#readme",
   "dependencies": {
-    "bluebird": "3.3.5",
-    "chance": "1.0.3",
-    "config": "1.20.1",
-    "hapiest-vo": "0.0.4",
-    "joi": "8.1.0",
-    "lodash": "4.13.1",
-    "mysql": "2.10.2",
-    "squel": "5.2.1"
+    "bluebird": "3.4.7",
+    "chance": "1.0.4",
+    "config": "1.24.0",
+    "hapiest-vo": "0.0.6",
+    "joi": "10.2.0",
+    "lodash": "4.17.4",
+    "mysql": "2.13.0",
+    "squel": "5.6.0"
   },
   "devDependencies": {
-    "async": "2.0.0-rc.4",
+    "async": "2.1.4",
     "config-uncached": "1.0.2",
     "faker": "3.1.0",
-    "hapiest-logger": "0.0.4",
+    "hapiest-logger": "0.1.1",
     "intercept-stdout": "0.1.2",
-    "mocha": "3.0.2",
-    "moment": "2.15.2",
+    "mocha": "3.2.0",
+    "moment": "2.17.1",
     "path": "0.12.7",
-    "should": "8.3.1",
-    "sinon": "1.17.4"
+    "should": "11.2.0",
+    "sinon": "1.17.7"
   }
 }


### PR DESCRIPTION
Bumps all dependencies in `package.json` to the latest versions.  Primarily motivated by getting an up-to-date version of [mysqljs](https://github.com/mysqljs/mysql/blob/master/Changes.md), which has fixed several bugs recently.  

None of the semver-MAJOR bumps appear to affect us, and the tests still pass, so ¯\_(ツ)_/¯