### PR TITLE
Insert Ignore Option

### DIFF
--- a/lib/mysqlDao.js
+++ b/lib/mysqlDao.js
@@ -43,11 +43,12 @@ class MysqlDao {
 
     /**
      * @param {object} createArgs column values to be inserted
-     * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
+     * @param {object} [opts] additional insert options
+     * @param {boolean} [opts.ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
      * @returns {Promise.<int,Error>} - ID of last inserted item; or 0 if ignoreOnDuplicateKey is true and nothing new was inserted
      */
-    create(createArgs, ignoreOnDuplicateKey) {
-        const sql = this._queryHelper.create(createArgs, ignoreOnDuplicateKey);
+    create(createArgs, opts) {
+        const sql = this._queryHelper.create(createArgs, opts);
         return this.createFromSql(sql);
     }
 
@@ -66,11 +67,12 @@ class MysqlDao {
 
     /**
      * @param {Array.<object>} createArgsArr
-     * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
+     * @param {object} [opts] additional insert options
+     * @param {boolean} [opts.ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
      * @returns {Promise.<int,Error>} - number of processed rows (including ignored duplicates)
      */
-    createBulk(createArgsArr, ignoreOnDuplicateKey) {
-        const sql = this._queryHelper.createBulk(createArgsArr, ignoreOnDuplicateKey);
+    createBulk(createArgsArr, opts) {
+        const sql = this._queryHelper.createBulk(createArgsArr, opts);
         return this.createBulkFromSql(sql);
     }
 

--- a/lib/mysqlDao.js
+++ b/lib/mysqlDao.js
@@ -44,7 +44,7 @@ class MysqlDao {
     /**
      * @param {object} createArgs value object to be inserted
      * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
-     * @returns {Promise.<int,Error>} - ID of last inserted item
+     * @returns {Promise.<int,Error>} - ID of last inserted item; or 0 if ignoreOnDuplicateKey is true and nothing new was inserted
      */
     create(createArgs, ignoreOnDuplicateKey) {
         const sql = this._queryHelper.create(createArgs, ignoreOnDuplicateKey);
@@ -66,10 +66,11 @@ class MysqlDao {
 
     /**
      * @param {Array.<object>} createArgsArr
-     * @returns {Promise.<int,Error>} - number of affected rows
+     * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
+     * @returns {Promise.<int,Error>} - number of processed rows (including ignored duplicates)
      */
-    createBulk(createArgsArr) {
-        const sql = this._queryHelper.createBulk(createArgsArr);
+    createBulk(createArgsArr, ignoreOnDuplicateKey) {
+        const sql = this._queryHelper.createBulk(createArgsArr, ignoreOnDuplicateKey);
         return this.createBulkFromSql(sql);
     }
 

--- a/lib/mysqlDao.js
+++ b/lib/mysqlDao.js
@@ -42,11 +42,12 @@ class MysqlDao {
     get mysqlService() { return this._mysqlService; }
 
     /**
-     * @param {object} createArgs
+     * @param {object} createArgs value object to be inserted
+     * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
      * @returns {Promise.<int,Error>} - ID of last inserted item
      */
-    create(createArgs) {
-        const sql = this._queryHelper.create(createArgs);
+    create(createArgs, ignoreOnDuplicateKey) {
+        const sql = this._queryHelper.create(createArgs, ignoreOnDuplicateKey);
         return this.createFromSql(sql);
     }
 

--- a/lib/mysqlDao.js
+++ b/lib/mysqlDao.js
@@ -42,7 +42,7 @@ class MysqlDao {
     get mysqlService() { return this._mysqlService; }
 
     /**
-     * @param {object} createArgs value object to be inserted
+     * @param {object} createArgs column values to be inserted
      * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
      * @returns {Promise.<int,Error>} - ID of last inserted item; or 0 if ignoreOnDuplicateKey is true and nothing new was inserted
      */

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -31,18 +31,22 @@ class MysqlDaoQueryHelper {
 
     /**
      * @param {object} createArgs
-     * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
+     * @param {object} [opts] additional insert options
+     * @param {boolean} [opts.ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
      * @returns {string}
      */
-    create(createArgs, ignoreOnDuplicateKey) {
-        return this.createBulk([createArgs], ignoreOnDuplicateKey);
+    create(createArgs, opts) {
+        return this.createBulk([createArgs], opts);
     }
 
     /**
      * @param {Array.<object>} createArgsArray
-     * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
+     * @param {object} [opts] additional insert options
+     * @param {boolean} [opts.ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
+     * @returns {string}
      */
-    createBulk(createArgsArray, ignoreOnDuplicateKey) {
+    createBulk(createArgsArray, opts) {
+        opts = opts || {};
         const cleanValues = [];
         createArgsArray.forEach(createArgs => {
             cleanValues.push(this._cleanAndMapValues(createArgs));
@@ -52,7 +56,7 @@ class MysqlDaoQueryHelper {
             Squel.useFlavour('mysql').insert().into(this._tableName)
                 .setFieldsRows(cleanValues, {dontQuote: true});
 
-        if (ignoreOnDuplicateKey) {
+        if (opts.ignoreOnDuplicateKey) {
             //INSERT ... IGNORE actually ignores ALL errors, not just duplicate key, so best practice is to "update"
             // a duplicate setting a column to itself
             const firstField = Object.keys(cleanValues[0])[0];

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -35,20 +35,7 @@ class MysqlDaoQueryHelper {
      * @returns {string}
      */
     create(createArgs, ignoreOnDuplicateKey) {
-        const cleanValues = this._cleanAndMapValues(createArgs);
-
-        const sqlBuilder =
-            Squel.useFlavour('mysql').insert().into(this._tableName)
-                .setFields(cleanValues, {dontQuote: true});
-
-            if (ignoreOnDuplicateKey) {
-                //INSERT ... IGNORE actually ignores ALL errors, not just duplicate key, so best practice is to "update"
-                // a duplicate setting a column to itself
-                const firstField = Object.keys(cleanValues)[0];
-                sqlBuilder.onDupUpdate(firstField, firstField, {dontQuote: true})
-            }
-
-        return sqlBuilder.toString();
+        return this.createBulk([createArgs], ignoreOnDuplicateKey);
     }
 
     /**

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -31,16 +31,24 @@ class MysqlDaoQueryHelper {
 
     /**
      * @param {object} createArgs
+     * @param {boolean} [ignoreOnDuplicateKey] if true an INSERT ... IGNORE statement wil be used
      * @returns {string}
      */
-    create(createArgs) {
+    create(createArgs, ignoreOnDuplicateKey) {
         const cleanValues = this._cleanAndMapValues(createArgs);
 
-        const sql =
-            Squel.insert().into(this._tableName)
-                .setFields(cleanValues, {dontQuote: true})
-                .toString();
-        return sql;
+        const sqlBuilder =
+            Squel.useFlavour('mysql').insert().into(this._tableName)
+                .setFields(cleanValues, {dontQuote: true});
+
+            if (ignoreOnDuplicateKey) {
+                //INSERT ... IGNORE actually ignores ALL errors, not just duplicate key, so best practice is to "update"
+                // a duplicate setting a column to itself
+                const firstField = Object.keys(cleanValues)[0];
+                sqlBuilder.onDupUpdate(firstField, firstField, {dontQuote: true})
+            }
+
+        return sqlBuilder.toString();
     }
 
     /**

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -53,18 +53,26 @@ class MysqlDaoQueryHelper {
 
     /**
      * @param {Array.<object>} createArgsArray
+     * @param {boolean} [ignoreOnDuplicateKey] if true an INSERT ... IGNORE statement wil be used
      */
-    createBulk(createArgsArray) {
+    createBulk(createArgsArray, ignoreOnDuplicateKey) {
         const cleanValues = [];
         createArgsArray.forEach(createArgs => {
             cleanValues.push(this._cleanAndMapValues(createArgs));
         });
 
-        const sql =
-            Squel.insert().into(this._tableName)
-                .setFieldsRows(cleanValues, {dontQuote: true})
-                .toString();
-        return sql;
+        const sqlBuilder =
+            Squel.useFlavour('mysql').insert().into(this._tableName)
+                .setFieldsRows(cleanValues, {dontQuote: true});
+
+        if (ignoreOnDuplicateKey) {
+            //INSERT ... IGNORE actually ignores ALL errors, not just duplicate key, so best practice is to "update"
+            // a duplicate setting a column to itself
+            const firstField = Object.keys(cleanValues[0])[0];
+            sqlBuilder.onDupUpdate(firstField, firstField, {dontQuote: true})
+        }
+
+        return sqlBuilder.toString();
     }
 
     /**

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -31,7 +31,7 @@ class MysqlDaoQueryHelper {
 
     /**
      * @param {object} createArgs
-     * @param {boolean} [ignoreOnDuplicateKey] if true an INSERT ... IGNORE statement wil be used
+     * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
      * @returns {string}
      */
     create(createArgs, ignoreOnDuplicateKey) {
@@ -40,7 +40,7 @@ class MysqlDaoQueryHelper {
 
     /**
      * @param {Array.<object>} createArgsArray
-     * @param {boolean} [ignoreOnDuplicateKey] if true an INSERT ... IGNORE statement wil be used
+     * @param {boolean} [ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
      */
     createBulk(createArgsArray, ignoreOnDuplicateKey) {
         const cleanValues = [];

--- a/lib/mysqlModificationResultFactory.js
+++ b/lib/mysqlModificationResultFactory.js
@@ -8,11 +8,13 @@ class MysqlModificationResultFactory {
      * @param {OkPacket} mysqlResult
      */
     static createFromResult(mysqlResult) {
+
         const resultObj = {
             affectedRows: mysqlResult.affectedRows,
             insertId: mysqlResult.insertId,
             changedRows: mysqlResult.changedRows
         };
+
         return new MysqlInsertResult(resultObj);
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A wrapper around mysql that provides a very descriptive way of running queries.",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=test node_modules/mocha/bin/mocha ./test/unit"
+    "test": "NODE_ENV=test node_modules/mocha/bin/mocha ./test/unit --timeout 10000"
   },
   "repository": {
     "type": "git",

--- a/test/unit/test-mysqlDao.js
+++ b/test/unit/test-mysqlDao.js
@@ -212,6 +212,14 @@ describe('MysqlDao', function() {
                         });
                     return Promise.all([checkRowPromise]);
                 });
+            }).then(() => {
+                return userDao.create(
+                    {firstName: 'Throw', lastName: 'Error', email: 'existing@email.com'}
+                ).then(() => {
+                    Should.fail('No duplicate key error when it should have been');
+                })
+            }).catch(e => {
+                e.message.should.match(/mysql/i);
             });
         });
 
@@ -297,9 +305,23 @@ describe('MysqlDao', function() {
                         });
 
                     return Promise.all([checkRowPromise1, checkRowPromise2, checkRowPromise3]);
+                }).then(() => {
+                    return userDao.createBulk(
+                        [
+                            {firstName: 'John', lastName: 'Doe', email: 'john.doe@gmail.com'},
+                            {firstName: 'Ignore', lastName: 'Me', email: 'existing@email.com'},
+                            {firstName: 'Jane', lastName: 'Doe', email: 'jane.doe@gmail.com'},
+                            {firstName: 'Also', lastName: 'Ignore', email: 'existing@email.com'},
+                        ]
+                    ).then(() => {
+                        Should.fail('No duplicate key error when it should have been');
+                    })
+                }).catch(e => {
+                    e.message.should.match(/mysql/i);
                 });
             });
         });
+
     });
 
     describe('upsert', function() {

--- a/test/unit/test-mysqlDao.js
+++ b/test/unit/test-mysqlDao.js
@@ -193,23 +193,25 @@ describe('MysqlDao', function() {
                 `VALUES ('Already','Here','existing@email.com')`
             ).then(insertResult => {
 
+                insertResult.affectedRows.should.equal(1);
+
                 return userDao.create(
-                    new UserCreateArgs({firstName: 'Ignore', lastName: 'Me', email: 'existing@email.com'}),
+                    {firstName: 'Ignore', lastName: 'Me', email: 'existing@email.com'},
                     true
                 ).then(id => {
 
-                        Should.exist(id);
-                        id.should.be.a.Number();
+                    Should.exist(id);
+                    id.should.equal(0);
 
-                        const checkRowPromise = mysqlService.selectOne(`SELECT * FROM users WHERE email = 'existing@email.com'`)
-                            .then(dbRow => {
-                                Should.exist(dbRow);
-                                dbRow.first_name.should.eql('Already');
-                                dbRow.last_name.should.eql('Here');
-                                dbRow.email.should.eql('existing@email.com');
-                            });
-                        return Promise.all([checkRowPromise]);
-                    })
+                    const checkRowPromise = mysqlService.selectOne(`SELECT * FROM users WHERE email = 'existing@email.com'`)
+                        .then(dbRow => {
+                            Should.exist(dbRow);
+                            dbRow.first_name.should.eql('Already');
+                            dbRow.last_name.should.eql('Here');
+                            dbRow.email.should.eql('existing@email.com');
+                        });
+                    return Promise.all([checkRowPromise]);
+                });
             });
         });
 
@@ -249,6 +251,54 @@ describe('MysqlDao', function() {
 
                     return Promise.all([checkRowPromise1, checkRowPromise2]);
                 });
+        });
+
+        it('Should respect duplicate ignore option', () => {
+            return mysqlService.insert(
+                `INSERT INTO users (first_name, last_name, email) ` +
+                `VALUES ('Already','Here','existing@email.com')`
+            ).then(insertResult => {
+
+                insertResult.affectedRows.should.equal(1);
+
+                return userDao.createBulk(
+                    [
+                        {firstName: 'John', lastName: 'Doe', email: 'john.doe@gmail.com'},
+                        {firstName: 'Ignore', lastName: 'Me', email: 'existing@email.com'},
+                        {firstName: 'Jane', lastName: 'Doe', email: 'jane.doe@gmail.com'},
+                        {firstName: 'Also', lastName: 'Ignore', email: 'existing@email.com'},
+                    ], true
+                ).then(numRows => {
+                    Should.exist(numRows);
+                    numRows.should.eql(4);
+
+                    const checkRowPromise1 = mysqlService.selectOne(`SELECT * FROM users WHERE email = 'existing@email.com'`)
+                        .then(dbRow => {
+                            Should.exist(dbRow);
+                            dbRow.first_name.should.eql('Already');
+                            dbRow.last_name.should.eql('Here');
+                            dbRow.email.should.eql('existing@email.com');
+                        });
+
+                    const checkRowPromise2 = mysqlService.selectOne(`SELECT * FROM users WHERE email = 'john.doe@gmail.com'`)
+                        .then(dbRow => {
+                            Should.exist(dbRow);
+                            dbRow.first_name.should.eql('John');
+                            dbRow.last_name.should.eql('Doe');
+                            dbRow.email.should.eql('john.doe@gmail.com');
+                        });
+
+                    const checkRowPromise3 = mysqlService.selectOne(`SELECT * FROM users WHERE email = 'jane.doe@gmail.com'`)
+                        .then(dbRow => {
+                            Should.exist(dbRow);
+                            dbRow.first_name.should.eql('Jane');
+                            dbRow.last_name.should.eql('Doe');
+                            dbRow.email.should.eql('jane.doe@gmail.com');
+                        });
+
+                    return Promise.all([checkRowPromise1, checkRowPromise2, checkRowPromise3]);
+                });
+            });
         });
     });
 

--- a/test/unit/test-mysqlDao.js
+++ b/test/unit/test-mysqlDao.js
@@ -197,7 +197,7 @@ describe('MysqlDao', function() {
 
                 return userDao.create(
                     {firstName: 'Ignore', lastName: 'Me', email: 'existing@email.com'},
-                    true
+                    {ignoreOnDuplicateKey: true}
                 ).then(id => {
 
                     Should.exist(id);
@@ -275,7 +275,7 @@ describe('MysqlDao', function() {
                         {firstName: 'Ignore', lastName: 'Me', email: 'existing@email.com'},
                         {firstName: 'Jane', lastName: 'Doe', email: 'jane.doe@gmail.com'},
                         {firstName: 'Also', lastName: 'Ignore', email: 'existing@email.com'},
-                    ], true
+                    ], {ignoreOnDuplicateKey: true}
                 ).then(numRows => {
                     Should.exist(numRows);
                     numRows.should.eql(4);

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -74,6 +74,18 @@ describe('MysqlDaoQueryHelper', function() {
             sql.should.eql(`INSERT INTO users (first_name, last_name, password, date_added) VALUES ('firstName', 'lastName', TRIM("   mybadpasswordinput    "), '1990-01-05 13:30:00.000')`);
         });
 
+        it('Should generate an INSERT statement to handle ignoring duplicate keys', function() {
+            const sql = mysqlDaoQueryHelper.create({
+                firstName: 'firstName',
+                lastName: 'lastName',
+                password: { raw: 'TRIM("   mybadpasswordinput    ")' },
+                dateAdded: new Date('1990-01-05T13:30:00Z')
+            }, {ignoreOnDuplicateKey: true});
+
+            Should.exist(sql);
+            sql.should.eql(`INSERT INTO users (first_name, last_name, password, date_added) VALUES ('firstName', 'lastName', TRIM("   mybadpasswordinput    "), '1990-01-05 13:30:00.000') ON DUPLICATE KEY UPDATE first_name = first_name`);
+        });
+
     });
 
     describe('createBulk', function() {
@@ -87,6 +99,18 @@ describe('MysqlDaoQueryHelper', function() {
             Should.exist(sql);
 
             sql.should.eql("INSERT INTO users (first_name, last_name, password) VALUES ('firstName', 'lastName', 'boom!'), ('John', 'Doe', 'badpassword'), ('Jane', 'Doe', 'foundrydc')");
+        });
+
+        it('Should generate an INSERT statement to handle ignoring duplicate keys', function() {
+
+            const sql = mysqlDaoQueryHelper.createBulk([
+                {firstName: 'firstName', lastName: 'lastName', password: 'boom!'},
+                {firstName: 'John', lastName: 'Doe', password: 'badpassword'},
+                {firstName: 'Jane', lastName: 'Doe', password: 'foundrydc'}
+            ], {ignoreOnDuplicateKey: true});
+            Should.exist(sql);
+
+            sql.should.eql("INSERT INTO users (first_name, last_name, password) VALUES ('firstName', 'lastName', 'boom!'), ('John', 'Doe', 'badpassword'), ('Jane', 'Doe', 'foundrydc') ON DUPLICATE KEY UPDATE first_name = first_name");
         });
 
     });


### PR DESCRIPTION
Sometimes when inserting into a MySQL table you want to ignore duplicate keys. This PR adds that option to `create()` and `createBulk()`.

Rather then doing something like `INSERT... SELECT` with a `LEFT JOIN` back to the table and doing `WHERE id IS NULL`, we can leverage MySQL's `ON DUPLICATE KEY`. This approach was done as `INSERT IGNORE` ignores _all_ errors, not just duplicate keys.