### PR TITLE
Perf no includes

### DIFF
--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -27,6 +27,8 @@ class MysqlDaoQueryHelper {
             ne: '!=',
             raw: ''
         };
+
+        this._squel = Squel.useFlavour('mysql');
     }
 
     /**
@@ -42,18 +44,16 @@ class MysqlDaoQueryHelper {
     /**
      * @param {Array.<object>} createArgsArray
      * @param {object} [opts] additional insert options
-     * @param {boolean} [opts.ignoreOnDuplicateKey] if true, insert will ignore duplicate keys
+     * @param {boolean} [opts.ignoreOnDuplicateKey=false] if true, insert will ignore duplicate keys
+     * @param {boolean} [opts.dontCleanMysqlFunctions=true] allow some mysql expressions in your VALUES.
+     *   Disable for a small performance improvenment.
      * @returns {string}
      */
-    createBulk(createArgsArray, opts) {
-        opts = opts || {};
-        const cleanValues = [];
-        createArgsArray.forEach(createArgs => {
-            cleanValues.push(this._cleanAndMapValues(createArgs));
-        });
+    createBulk(createArgsArray, opts = {}) {
+        const cleanValues = this._cleanAndMapValues(createArgsArray, opts.dontCleanMysqlFunctions);
 
         const sqlBuilder =
-            Squel.useFlavour('mysql').insert().into(this._tableName)
+            this._squel.insert().into(this._tableName)
                 .setFieldsRows(cleanValues, {dontQuote: true});
 
         if (opts.ignoreOnDuplicateKey) {
@@ -76,7 +76,7 @@ class MysqlDaoQueryHelper {
         const cleanOnDupUpdateValues = this._cleanAndMapValues(onDupUpdateArgs);
 
         let upsert =
-            Squel.useFlavour('mysql').insert().into(this._tableName)
+            this._squel.insert().into(this._tableName)
                 .setFields(cleanInsertValues, {dontQuote: true});
 
         Object.keys(cleanOnDupUpdateValues).forEach(property => {
@@ -89,17 +89,18 @@ class MysqlDaoQueryHelper {
     /**
      * @param {Array.<object>} insertArgsArray
      * @param {object|Array} onDupUpdateArgs If an object, update columns with values defined by the object keys.  If
-     * an array, update the listed columns with the insert value.
+     *    an array, update the listed columns with the insert value.
+     * @param {object} [opts] additional insert options
+     * @param {boolean} [opts.dontCleanMysqlFunctions=true] allow some mysql expressions in your VALUES
+     *    Disable for a small performance improvenment.
      * @returns {string}
      */
-    upsertBulk(insertArgsArray, onDupUpdateArgs) {
-        const cleanValues = [];
-        insertArgsArray.forEach(insertArgsArray => {
-            cleanValues.push(this._cleanAndMapValues(insertArgsArray));
-        });
+    upsertBulk(insertArgsArray, onDupUpdateArgs, opts = {}) {
+
+        const cleanValues = this._cleanAndMapValues(insertArgsArray, opts.dontCleanMysqlFunctions);
 
         const upsert =
-            Squel.useFlavour('mysql').insert().into(this._tableName)
+            this._squel.insert().into(this._tableName)
                 .setFieldsRows(cleanValues, {dontQuote: true});
 
         if (_.isArray(onDupUpdateArgs)) {
@@ -207,7 +208,7 @@ class MysqlDaoQueryHelper {
         // replace characters.  Before this, a URL with query parameter such as youtube.com/?q=abc would cause the
         // ? to be replaced with 'undefined'.  Stupidly annoying!
         let sqlObject =
-            Squel.select({parameterCharacter: '!!@@##$$%%'})
+            this._squel.select({parameterCharacter: '!!@@##$$%%'})
                 .from(this._tableName);
 
         sqlObject = this._appendWhereClause(sqlObject, whereClause);
@@ -232,7 +233,7 @@ class MysqlDaoQueryHelper {
     _getCountBase(whereClause, options) {
         options = options || {};
         let sqlObject =
-            Squel.select({parameterCharacter: '!!@@##$$%%'})
+            this._squel.select({parameterCharacter: '!!@@##$$%%'})
             .field('COUNT(*)', "count")
             .from(this._tableName);
 
@@ -251,7 +252,7 @@ class MysqlDaoQueryHelper {
         const cleanUpdateValues = this._cleanAndMapValues(updateArgs);
 
         let sqlObject =
-            Squel.update({parameterCharacter: '!!@@##$$%%'}) // See comment in _getBase for explanation of paramChar - using sequence likely never to be inserted
+            this._squel.update({parameterCharacter: '!!@@##$$%%'}) // See comment in _getBase for explanation of paramChar - using sequence likely never to be inserted
                 .table(this._tableName)
                 .setFields(cleanUpdateValues, {dontQuote: true});
 
@@ -261,7 +262,7 @@ class MysqlDaoQueryHelper {
 
     _deleteBase(whereClause) {
         let sqlObject =
-            Squel.delete({parameterCharacter: '!!@@##$$%%'}) // See comment in _getBase for explanation of paramChar
+            this._squel.delete({parameterCharacter: '!!@@##$$%%'}) // See comment in _getBase for explanation of paramChar
                 .from(this._tableName);
 
         sqlObject = this._appendWhereClause(sqlObject, whereClause);
@@ -269,65 +270,88 @@ class MysqlDaoQueryHelper {
     }
 
     /**
-     * @param {object} obj
-     * @param {object} [config]
-     * @param {boolean} [config.dontCleanMysqlFunctions] - defaults to true; includes CURRENT_TIMESTAMP and NOW();
-     *
-     * @returns {object} - cleans the values and returns an object with snake case props --> clean values
+     * @private
+     * @param {Object|Object[]} obj
+     * @param {Boolean} [dontCleanMysqlFunctions] whether or not to allow MySQL functions to exist in values
+     * @returns {Object} - cleans the values and returns an object with snake_case props --> clean values
      */
-    _cleanAndMapValues(obj, config) {
-        const defaultConfig = {
-            dontCleanMysqlFunctions: true
-        };
+    _cleanAndMapValues(obj, dontCleanMysqlFunctions = true) {
+        if (Array.isArray(obj)) {
+            const propertyMappings = MysqlDaoQueryHelper._getPropertyMappings(objs[0]);
+            return objs.map(obj => this._cleanAndMapObjectProperties(obj, propertyMappings, dontCleanMysqlFunctions));
+        } else {
+            const propertyMappings = MysqlDaoQueryHelper._getPropertyMappings(obj);
+            return this._cleanAndMapObjectProperties(obj, propertyMappings, dontCleanMysqlFunctions);
+        }
+    }
 
-        config = _.merge(defaultConfig, config);
-
-        if (obj instanceof VO) {
-            obj = obj.toJsObj();
-        } else if (typeof(obj.toJsObj) === 'function') {
+    /**
+     * @private
+     * @param {Object} obj
+     * @returns {Object} - a lookup object mapping property names to their snake_cased equivalents
+     */
+    static _getPropertyMappings(obj) {
+        if (typeof(obj.toJsObj) === 'function') {
             obj = obj.toJsObj();
         } else if (typeof(obj.toJSON) === 'function') {
             obj = obj.toJSON();
         }
 
-        const properties = Object.keys(obj);
+        const mappings = {};
+        Object.keys(obj).forEach(key => {
+            mappings[key] = _.snakeCase(key);
+        });
+        return mappings;
+    }
+
+    /**
+     * Cleans values and maps them to snake_cased property names.
+     * This method should only be called by _cleanAndMapValues()
+     * @private
+     * @param {object} obj
+     * @param {Object} propertyMappings maps property names to their snake_cased equivalents
+     * @param {Boolean} dontCleanMysqlFunctions whether or not to allow MySQL functions to exist in values
+     * @returns {object} - cleans the values and returns an object with snake_case props --> clean values
+     */
+    _cleanAndMapObjectProperties(obj, propertyMappings, dontCleanMysqlFunctions) {
+        if (typeof(obj.toJsObj) === 'function') {
+            obj = obj.toJsObj();
+        } else if (typeof(obj.toJSON) === 'function') {
+            obj = obj.toJSON();
+        }
+
         const cleanValues = {};
+        const clean = dontCleanMysqlFunctions ? this.cleanSpecial.bind(this) : this.clean.bind(this);
 
-        properties.forEach(property => {
+        Object.keys(obj).forEach(property => {
             const uncleanValue = obj[property];
-            const snakeCaseProperty = _.snakeCase(property);
-
-            if (uncleanValue === null || ['string', 'number', 'boolean', 'undefined'].indexOf(typeof uncleanValue) !== -1) {
+            const mappedProp = propertyMappings[property];
+            if (uncleanValue === null || typeof uncleanValue === 'string' || typeof uncleanValue === 'number' || typeof uncleanValue === 'boolean' || typeof uncleanValue === 'undefined') {
                 // Escaping primitive values
-                const cleanValue = config.dontCleanMysqlFunctions ? this.cleanSpecial(uncleanValue) : this.clean(uncleanValue);
-                cleanValues[snakeCaseProperty] = cleanValue;
+                cleanValues[mappedProp] = clean(uncleanValue);
             } else if (_.has(uncleanValue, 'raw')) {
-                const cleanValue = uncleanValue.raw;
-                cleanValues[snakeCaseProperty] = cleanValue;
+                cleanValues[mappedProp] = uncleanValue.raw;
             } else if (_.isDate(uncleanValue) || uncleanValue instanceof Moment) {
-                const cleanValue = config.dontCleanMysqlFunctions ? this.cleanSpecial(uncleanValue) : this.clean(uncleanValue);
-                cleanValues[snakeCaseProperty] = cleanValue;
+                cleanValues[mappedProp] = clean(uncleanValue);
             } else if (_.isArray(uncleanValue)) {
                 // Escaping array values
                 const cleanValueArray = [];
                 uncleanValue.forEach(uncleanVal => {
                     if (['string', 'number', 'boolean'].indexOf(typeof(uncleanVal)) !== -1) {
-                        const cleanVal = config.dontCleanMysqlFunctions ? this.cleanSpecial(uncleanVal) : this.clean(uncleanVal);
-                        cleanValueArray.push(cleanVal)
+                        cleanValueArray.push(clean(uncleanVal))
                     }
                 });
                 if (cleanValueArray.length > 0) {
-                    cleanValues[snakeCaseProperty] = cleanValueArray;
+                    cleanValues[mappedProp] = cleanValueArray;
                 }
             } else if (_.isObject(uncleanValue)) {
                 this._validateQueryObject(uncleanValue);
-                const cleanQueryObj = this._cleanAndMapValues(uncleanValue, config);
                 // Escape the values in the operator object
+                const cleanQueryObj = this._cleanAndMapValues(uncleanValue, dontCleanMysqlFunctions);
                 if (_.size(cleanQueryObj) > 0) {
-                    cleanValues[snakeCaseProperty] = cleanQueryObj;
+                    cleanValues[mappedProp] = cleanQueryObj;
                 }
             }
-
         });
 
         return cleanValues;

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -185,7 +185,7 @@ class MysqlDaoQueryHelper {
      */
     cleanSpecial(uncleanValue) {
         let cleanValue = null;
-        if (_.includes(['current_timestamp','now()','is null', 'is not null'],_.toLower(uncleanValue))) {
+        if (['current_timestamp','now()','is null', 'is not null'].indexOf(_.toLower(uncleanValue)) !== -1) {
             cleanValue = uncleanValue;
         } else {
             const valueToClean = typeof(uncleanValue) === 'undefined' ? null : uncleanValue;
@@ -297,7 +297,7 @@ class MysqlDaoQueryHelper {
             const uncleanValue = obj[property];
             const snakeCaseProperty = _.snakeCase(property);
 
-            if (_.includes(['string', 'number', 'boolean', 'undefined'], typeof(uncleanValue)) || uncleanValue === null) {
+            if (uncleanValue === null || ['string', 'number', 'boolean', 'undefined'].indexOf(typeof uncleanValue) !== -1) {
                 // Escaping primitive values
                 const cleanValue = config.dontCleanMysqlFunctions ? this.cleanSpecial(uncleanValue) : this.clean(uncleanValue);
                 cleanValues[snakeCaseProperty] = cleanValue;
@@ -311,7 +311,7 @@ class MysqlDaoQueryHelper {
                 // Escaping array values
                 const cleanValueArray = [];
                 uncleanValue.forEach(uncleanVal => {
-                    if (_.includes(['string', 'number', 'boolean'], typeof(uncleanVal))) {
+                    if (['string', 'number', 'boolean'].indexOf(typeof(uncleanVal)) !== -1) {
                         const cleanVal = config.dontCleanMysqlFunctions ? this.cleanSpecial(uncleanVal) : this.clean(uncleanVal);
                         cleanValueArray.push(cleanVal)
                     }

--- a/lib/testing-helper/mysqlDatabaseSetupDao.js
+++ b/lib/testing-helper/mysqlDatabaseSetupDao.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Promise = require('bluebird');
-const Async = require('async');
 
 class MysqlDatabaseSetupDao {
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "joi": "10.2.0",
     "lodash": "4.17.4",
     "mysql": "2.13.0",
-    "squel": "5.6.0"
+    "squel": "5.9.1"
   },
   "devDependencies": {
     "async": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "squel": "5.9.1"
   },
   "devDependencies": {
-    "async": "2.1.4",
     "config-uncached": "1.0.2",
     "faker": "3.1.0",
     "hapiest-logger": "0.1.1",

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -584,7 +584,7 @@ describe('MysqlDaoQueryHelper', function() {
                 dateAgain: 'NOW()',
                 someNullField: 'IS NULL',
                 nonNullField: 'IS NOT NULL'
-            }, {dontCleanMysqlFunctions: false});
+            }, false);
             Should.exist(output);
             output.should.have.properties(['first_name','date_created']);
             output.first_name.should.eql("'firstName'");


### PR DESCRIPTION
Includes a variety of performance improvements for large INSERT and UPDATE queries.  

* Updates to Squel v5.9.1, which includes several of its own improvements
* Reduces the number of times that `_.snakeCase()` is called for large `INSERT` queries (it's surprisingly expensive!)
* Replace a frequently-called `_.includes()` with a slightly-awkward boolean expression.
* Reuse the same squel instance across multiple queries.  (Small improvement, but noticeable in very large workloads)

---

## Benchmark

Create 1000 insert queries of [5000 rows](https://gist.github.com/schmod/ca6dc01dd4cb0aaf9acd22e0e770c50a) each.  Except where noted, all tests were run on Node v6.10.2 (the current LTS).

```js
const fs = require('fs');
const Mysql = require('mysql');
const MysqlDaoQueryHelper = require('./lib/mysqlDaoQueryHelper');

const cleanFunction = value => Mysql.escape(value, false, 'utc');
const mysqlDaoQueryHelper = new MysqlDaoQueryHelper('users', cleanFunction);

const rows = JSON.parse(fs.readFileSync('./rows.json', 'utf8'));

for(let i = 0; i < 1000; i++) {
  let params = mysqlDaoQueryHelper.createBulk(rows);
}
```

### Before

```shell
$ time node perf.js

real	0m38.500s
user	0m38.384s
sys	0m0.211s
```

### After (`dontCleanMysqlFunctions=true`)

```shell
$ time node perf.js

real	0m6.298s
user	0m6.270s
sys	0m0.098s
```

### After (`dontCleanMysqlFunctions=false`)

```shell
$ time node perf.js

real	0m5.458s
user	0m5.457s
sys	0m0.089s
```