### PR TITLE
[Query Objects] Support "ne: null" in query objects.

### DIFF
--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -402,8 +402,9 @@ class MysqlDaoQueryHelper {
             if (i++ > 0) {
                 sql += ' AND ';
             }
-            const cleanedValue = MysqlDaoQueryHelper._cleanValueForOperator(operator, value);
-            sql += `${columnName} ${this._queryOperators[operator]} ${cleanedValue}`;
+            const cleanQueryOperator = this._cleanQueryOperator(operator, value);
+            const cleanedValue = this._cleanValueForOperator(operator, value);
+            sql += `${columnName} ${cleanQueryOperator} ${cleanedValue}`;
         });
 
         return sql;
@@ -417,14 +418,24 @@ class MysqlDaoQueryHelper {
      * @returns {*}
      * @private
      */
-    static _cleanValueForOperator(operator, value) {
-        if (_.includes(['in', 'nin', 'not_in'], operator) && _.isArray(value)) {
+    _cleanValueForOperator(operator, value) {
+        if (_.includes(['in', 'nin', 'not_in'], operator)) {
+            value = _.castArray(value);
             const joinedValues = value.join(',');
             return `(${joinedValues})`;
         }
 
         return value;
     }
+
+    _cleanQueryOperator(operator, value) {
+        let cleanOperator = this._queryOperators[operator];
+        if (operator === 'ne' && value === 'NULL') {
+            cleanOperator = 'IS NOT';
+        }
+        return cleanOperator;
+    }
+
 }
 
 module.exports = MysqlDaoQueryHelper;

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -308,6 +308,17 @@ describe('MysqlDaoQueryHelper', function() {
             sql.should.eql("SELECT * FROM users WHERE (id >= 5 AND id <= 10)");
         });
 
+        it('Should generate a SELECT statement with a query object and ne: null', function() {
+            const sql = mysqlDaoQueryHelper.getAll({
+                id: {
+                    ne: null
+                }
+            });
+            Should.exist(sql);
+
+            sql.should.eql("SELECT * FROM users WHERE (id IS NOT NULL)");
+        });
+
         it('Should generate a SELECT statement with multiple query objects', function() {
             const sql = mysqlDaoQueryHelper.getAll({
                 name: {
@@ -689,12 +700,12 @@ describe('MysqlDaoQueryHelper', function() {
 
     describe('_cleanValueForOperator', function() {
         it('Should clean array values for in and in operators', function() {
-            const cleanedValue = MysqlDaoQueryHelper._cleanValueForOperator('in', ['\'a\'','\'b\'','\'c\'']);
+            const cleanedValue = mysqlDaoQueryHelper._cleanValueForOperator('in', ['\'a\'','\'b\'','\'c\'']);
             cleanedValue.should.eql('(\'a\',\'b\',\'c\')');
         });
 
         it('Should pass the value for other operators through unchanged', function() {
-            const cleanedValue = MysqlDaoQueryHelper._cleanValueForOperator('gte', 5);
+            const cleanedValue = mysqlDaoQueryHelper._cleanValueForOperator('gte', 5);
             cleanedValue.should.eql(5);
         })
     });

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -709,4 +709,11 @@ describe('MysqlDaoQueryHelper', function() {
             cleanedValue.should.eql(5);
         })
     });
+
+    describe('_cleanQueryOperator', function() {
+        it('Should clean array values for in and in operators', function() {
+            const cleanedValue = mysqlDaoQueryHelper._cleanQueryOperator('ne', 'NULL');
+            cleanedValue.should.eql('IS NOT');
+        });
+    });
 });


### PR DESCRIPTION
Right now doing {ne: null} yields "!= NULL", but we need it to be "IS NOT NULL"