### PR TITLE
Disable auto snake and camelcase when dealing with a json path query

### DIFF
--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -303,7 +303,7 @@ class MysqlDaoQueryHelper {
 
         const mappings = {};
         Object.keys(obj).forEach(key => {
-            mappings[key] = _.snakeCase(key);
+            mappings[key] = key.includes('->') ? key :_.snakeCase(key);
         });
         return mappings;
     }
@@ -364,7 +364,7 @@ class MysqlDaoQueryHelper {
     _appendWhereClause(sqlObject, whereClause) {
         const cleanValues = this._cleanAndMapValues(whereClause);
         Object.keys(cleanValues).forEach(columnName => {
-            const whereClauseKey = _.camelCase(columnName);
+            const whereClauseKey = columnName.includes('->') ? columnName : _.camelCase(columnName);
             const uncleanValue = whereClause[whereClauseKey];
             const cleanValue = cleanValues[columnName];
 

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -303,7 +303,7 @@ class MysqlDaoQueryHelper {
 
         const mappings = {};
         Object.keys(obj).forEach(key => {
-            mappings[key] = key.includes('->') ? key :_.snakeCase(key);
+            mappings[key] = key.includes('->') ? key : _.snakeCase(key);
         });
         return mappings;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapiest-mysql",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "A wrapper around mysql that provides a very descriptive way of running queries.",
   "main": "index.js",
   "scripts": {

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -707,6 +707,32 @@ describe('MysqlDaoQueryHelper', function() {
             sqlString.should.eql("SELECT * FROM users WHERE (date_created = CURRENT_TIMESTAMP) AND (date_updated = NOW()) AND (email IS NULL) AND (first_name IS NOT NULL)");
         });
 
+        it('Should generate good WHERE clause when input contains JSON path query', function() {
+            const sqlObj = Squel.select().from('users');
+
+            mysqlDaoQueryHelper._appendWhereClause(sqlObj, {"meta->'$.is_active'": true});
+
+            const sqlString = sqlObj.toString();
+
+            sqlString.should.eql("SELECT * FROM users WHERE (meta->'$.is_active' = true)");
+        });
+
+    });
+
+    describe('_getPropertyMappings', function() {
+        it('Should convert property keys to snake_case, but not JSON path fields', function() {
+            const mapped = MysqlDaoQueryHelper._getPropertyMappings({
+                propertyOne: 1,
+                propertyTwo: 2,
+                "meta->'$.is_active'": true
+            });
+
+            mapped.should.eql({
+                propertyOne: 'property_one',
+                propertyTwo: 'property_two',
+                "meta->'$.is_active'": "meta->'$.is_active'"
+            });
+        });
     });
 
     describe('_cleanValueForOperator', function() {


### PR DESCRIPTION
This is a pretty simple change that enables passing in query fields for JSON objects, specifically containing `->`. I also looked in to other methods for enhancing JSON based queries, but this seemed like the simplest method of doing so without requiring a major refactor or rethink of the data access layer. 

Example:
```js
{ "meta->'$.ip'": '1.1.1.1' }
```

**Note:** I'm not sure auto converting between camel and snake case is best at this layer. It enforces strict opinions about the shape of the database thats being worked with. Namely that all fields come in as camelCase and are in the database as snake_case, which isn't always the _case_.