### PR TITLE
Quote columns

### DIFF
--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -57,7 +57,7 @@ class MysqlDaoQueryHelper {
         const cleanValues = this._cleanAndMapValues(createArgsArray, opts.dontCleanMysqlFunctions);
 
         const sqlBuilder =
-            this._squel.insert().into(this._tableName)
+            this._squel.insert({autoQuoteFieldNames: true}).into(this._tableName)
                 .setFieldsRows(cleanValues, {dontQuote: true});
 
         if (opts.ignoreOnDuplicateKey) {
@@ -80,7 +80,7 @@ class MysqlDaoQueryHelper {
         const cleanOnDupUpdateValues = this._cleanAndMapValues(onDupUpdateArgs);
 
         let upsert =
-            this._squel.insert().into(this._tableName)
+            this._squel.insert({autoQuoteFieldNames: true}).into(this._tableName)
                 .setFields(cleanInsertValues, {dontQuote: true});
 
         Object.keys(cleanOnDupUpdateValues).forEach(property => {
@@ -104,7 +104,7 @@ class MysqlDaoQueryHelper {
         const cleanValues = this._cleanAndMapValues(insertArgsArray, opts.dontCleanMysqlFunctions);
 
         const upsert =
-            this._squel.insert().into(this._tableName)
+            this._squel.insert({autoQuoteFieldNames: true}).into(this._tableName)
                 .setFieldsRows(cleanValues, {dontQuote: true});
 
         if (_.isArray(onDupUpdateArgs)) {
@@ -212,7 +212,7 @@ class MysqlDaoQueryHelper {
         // replace characters.  Before this, a URL with query parameter such as youtube.com/?q=abc would cause the
         // ? to be replaced with 'undefined'.  Stupidly annoying!
         let sqlObject =
-            this._squel.select({parameterCharacter: '!!@@##$$%%'})
+            this._squel.select({parameterCharacter: '!!@@##$$%%', autoQuoteFieldNames: true})
                 .from(this._tableName);
 
         sqlObject = this._appendWhereClause(sqlObject, whereClause);
@@ -256,7 +256,7 @@ class MysqlDaoQueryHelper {
         const cleanUpdateValues = this._cleanAndMapValues(updateArgs);
 
         let sqlObject =
-            this._squel.update({parameterCharacter: '!!@@##$$%%'}) // See comment in _getBase for explanation of paramChar - using sequence likely never to be inserted
+            this._squel.update({parameterCharacter: '!!@@##$$%%', autoQuoteFieldNames: true}) // See comment in _getBase for explanation of paramChar - using sequence likely never to be inserted
                 .table(this._tableName)
                 .setFields(cleanUpdateValues, {dontQuote: true});
 
@@ -266,7 +266,7 @@ class MysqlDaoQueryHelper {
 
     _deleteBase(whereClause) {
         let sqlObject =
-            this._squel.delete({parameterCharacter: '!!@@##$$%%'}) // See comment in _getBase for explanation of paramChar
+            this._squel.delete({parameterCharacter: '!!@@##$$%%', autoQuoteFieldNames: true}) // See comment in _getBase for explanation of paramChar
                 .from(this._tableName);
 
         sqlObject = this._appendWhereClause(sqlObject, whereClause);

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -64,7 +64,7 @@ class MysqlDaoQueryHelper {
             //INSERT ... IGNORE actually ignores ALL errors, not just duplicate key, so best practice is to "update"
             // a duplicate setting a column to itself
             const firstField = Object.keys(cleanValues[0])[0];
-            sqlBuilder.onDupUpdate(firstField, firstField, {dontQuote: true})
+            sqlBuilder.onDupUpdate(`\`${firstField}\``, `\`${firstField}\``, {dontQuote: true})
         }
 
         return sqlBuilder.toString();
@@ -85,7 +85,7 @@ class MysqlDaoQueryHelper {
 
         Object.keys(cleanOnDupUpdateValues).forEach(property => {
             const cleanUpsertValue = cleanOnDupUpdateValues[property];
-            upsert.onDupUpdate(property, cleanUpsertValue, {dontQuote: true});
+            upsert.onDupUpdate(`\`${property}\``, cleanUpsertValue, {dontQuote: true});
         });
         return upsert.toString();
     }
@@ -110,13 +110,13 @@ class MysqlDaoQueryHelper {
         if (_.isArray(onDupUpdateArgs)) {
             onDupUpdateArgs.forEach(propName => {
                 const snakeCaseProp = _.snakeCase(propName);
-                upsert.onDupUpdate(snakeCaseProp, "VALUES(" + snakeCaseProp + ")", {dontQuote: true});
+                upsert.onDupUpdate(`\`${snakeCaseProp}\``, "VALUES(`" + snakeCaseProp + "`)", {dontQuote: true});
             });
         } else {
             const cleanOnDupUpdateValues = this._cleanAndMapValues(onDupUpdateArgs);
             Object.keys(cleanOnDupUpdateValues).forEach(property => {
                 const cleanUpsertValue = cleanOnDupUpdateValues[property];
-                upsert.onDupUpdate(property, cleanUpsertValue, {dontQuote: true});
+                upsert.onDupUpdate(`\`${property}\``, cleanUpsertValue, {dontQuote: true});
             });
         }
 

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -378,9 +378,14 @@ class MysqlDaoQueryHelper {
             } else if (_.isObject(cleanValue)) {
                 sqlObject = sqlObject.where(this._queryObjectToSql(columnName, cleanValue));
             } else if (columnName.includes('->')) {
-                jsonPathWithQuotedColumn = columnName
+                let jsonPathWithQuotedColumn = columnName
                     .split('->')
-                    .map((path, index) => index === 0 ? `\`${path}\`` : path)
+                    .map((path, index) => {
+                        const isFieldName = index === 0;
+                        const isQuoted = path[0] === '`' && path[path.length - 1] === '`';
+
+                        return isFieldName && !isQuoted ? `\`${path}\`` : path;
+                    })
                     .join('->');
                 sqlObject = sqlObject.where(`${jsonPathWithQuotedColumn} = ${cleanValue}`);
             } else {

--- a/lib/mysqlDaoQueryHelper.js
+++ b/lib/mysqlDaoQueryHelper.js
@@ -219,7 +219,7 @@ class MysqlDaoQueryHelper {
 
         if (options.sort) {
             Object.keys(options.sort).forEach(key => {
-                sqlObject = sqlObject.order(_.snakeCase(String(key)), String(options.sort[key]).toUpperCase() !== 'DESC');
+                sqlObject = sqlObject.order(`\`${_.snakeCase(String(key))}\``, String(options.sort[key]).toUpperCase() !== 'DESC');
             })
         }
         if (options.limit) sqlObject = sqlObject.limit(Number(options.limit));
@@ -369,16 +369,22 @@ class MysqlDaoQueryHelper {
             const cleanValue = cleanValues[columnName];
 
             if (uncleanValue === null || typeof(uncleanValue) === 'undefined') {
-                sqlObject = sqlObject.where(`${columnName} IS NULL`);
+                sqlObject = sqlObject.where(`\`${columnName}\` IS NULL`);
             } else if (cleanValue === 'IS NULL' || cleanValue === 'IS NOT NULL') {
-                sqlObject = sqlObject.where(`${columnName} ${cleanValue}`);
+                sqlObject = sqlObject.where(`\`${columnName}\` ${cleanValue}`);
             } else if (_.isArray(cleanValue)) {
                 const cleanValueList = cleanValue.join(',');
-                sqlObject = sqlObject.where(`${columnName} IN (${cleanValueList})`)
+                sqlObject = sqlObject.where(`\`${columnName}\` IN (${cleanValueList})`)
             } else if (_.isObject(cleanValue)) {
                 sqlObject = sqlObject.where(this._queryObjectToSql(columnName, cleanValue));
+            } else if (columnName.includes('->')) {
+                jsonPathWithQuotedColumn = columnName
+                    .split('->')
+                    .map((path, index) => index === 0 ? `\`${path}\`` : path)
+                    .join('->');
+                sqlObject = sqlObject.where(`${jsonPathWithQuotedColumn} = ${cleanValue}`);
             } else {
-                sqlObject = sqlObject.where(`${columnName} = ${cleanValue}`);
+                sqlObject = sqlObject.where(`\`${columnName}\` = ${cleanValue}`);
             }
         });
         return sqlObject;
@@ -405,7 +411,7 @@ class MysqlDaoQueryHelper {
             }
             const cleanQueryOperator = this._cleanQueryOperator(operator, value);
             const cleanedValue = this._cleanValueForOperator(operator, value);
-            sql += `${columnName} ${cleanQueryOperator} ${cleanedValue}`;
+            sql += `\`${columnName}\` ${cleanQueryOperator} ${cleanedValue}`;
         });
 
         return sql;

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -83,7 +83,7 @@ describe('MysqlDaoQueryHelper', function() {
             }, {ignoreOnDuplicateKey: true});
 
             Should.exist(sql);
-            sql.should.eql(`INSERT INTO users (\`first_name\`, \`last_name\`, \`password\`, \`date_added\`) VALUES ('firstName', 'lastName', TRIM("   mybadpasswordinput    "), '1990-01-05 13:30:00.000') ON DUPLICATE KEY UPDATE first_name = first_name`);
+            sql.should.eql(`INSERT INTO users (\`first_name\`, \`last_name\`, \`password\`, \`date_added\`) VALUES ('firstName', 'lastName', TRIM("   mybadpasswordinput    "), '1990-01-05 13:30:00.000') ON DUPLICATE KEY UPDATE \`first_name\` = \`first_name\``);
         });
 
     });
@@ -110,7 +110,7 @@ describe('MysqlDaoQueryHelper', function() {
             ], {ignoreOnDuplicateKey: true});
             Should.exist(sql);
 
-            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('firstName', 'lastName', 'boom!'), ('John', 'Doe', 'badpassword'), ('Jane', 'Doe', 'foundrydc') ON DUPLICATE KEY UPDATE first_name = first_name");
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('firstName', 'lastName', 'boom!'), ('John', 'Doe', 'badpassword'), ('Jane', 'Doe', 'foundrydc') ON DUPLICATE KEY UPDATE `first_name` = `first_name`");
         });
 
     });
@@ -120,14 +120,14 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.upsert({firstName: 'firstName', lastName: 'lastName', password: 'boom!'}, {password: 'ka-boom!'});
             Should.exist(sql);
 
-            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('firstName', 'lastName', 'boom!') ON DUPLICATE KEY UPDATE password = 'ka-boom!'");
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('firstName', 'lastName', 'boom!') ON DUPLICATE KEY UPDATE \`password\` = 'ka-boom!'");
         });
 
         it('Should generate an INSERT ... ON DUPLICATE KEY UPDATE statement for raw update args', function() {
             const sql = mysqlDaoQueryHelper.upsert({firstName: 'firstName', lastName: 'lastName', password: 'boom!'}, {password: { raw: 'TRIM("   mybadpasswordinput    ")' } });
             Should.exist(sql);
 
-            sql.should.eql(`INSERT INTO users (\`first_name\`, \`last_name\`, \`password\`) VALUES ('firstName', 'lastName', 'boom!') ON DUPLICATE KEY UPDATE password = TRIM("   mybadpasswordinput    ")`);
+            sql.should.eql(`INSERT INTO users (\`first_name\`, \`last_name\`, \`password\`) VALUES ('firstName', 'lastName', 'boom!') ON DUPLICATE KEY UPDATE \`password\` = TRIM("   mybadpasswordinput    ")`);
         });
 
         it('Should generate an INSERT ... ON DUPLICATE KEY UPDATE statement for multiple rows with insert values', function() {
@@ -144,7 +144,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.upsertBulk(insertArgs, updateArgs);
             Should.exist(sql);
 
-            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('f1', 'l1', 'p1'), ('f2', 'l2', 'p2'), ('f3', 'l3', 'p3') ON DUPLICATE KEY UPDATE first_name = VALUES(first_name), last_name = VALUES(last_name), password = VALUES(password)");
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('f1', 'l1', 'p1'), ('f2', 'l2', 'p2'), ('f3', 'l3', 'p3') ON DUPLICATE KEY UPDATE `first_name` = VALUES(`first_name`), `last_name` = VALUES(`last_name`), `password` = VALUES(`password`)");
         });
 
         it('Should generate an INSERT ... ON DUPLICATE KEY UPDATE statement for multiple rows with specific values', function() {
@@ -161,7 +161,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.upsertBulk(insertArgs, updateArgs);
             Should.exist(sql);
 
-            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('f1', 'l1', 'p1'), ('f2', 'l2', 'p2'), ('f3', 'l3', 'p3') ON DUPLICATE KEY UPDATE password = 'newpassword1234'");
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('f1', 'l1', 'p1'), ('f2', 'l2', 'p2'), ('f3', 'l3', 'p3') ON DUPLICATE KEY UPDATE `password` = 'newpassword1234'");
         });
     });
 

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -714,7 +714,17 @@ describe('MysqlDaoQueryHelper', function() {
 
             const sqlString = sqlObj.toString();
 
-            sqlString.should.eql("SELECT * FROM users WHERE (meta->'$.is_active' = true)");
+            sqlString.should.eql("SELECT * FROM users WHERE (`meta`->'$.is_active' = true)");
+        });
+
+        it('Should generate good WHERE clause when input contains JSON path query with already quoted column name', function() {
+            const sqlObj = Squel.select().from('users');
+
+            mysqlDaoQueryHelper._appendWhereClause(sqlObj, {"`meta`->'$.is_active'": true});
+
+            const sqlString = sqlObj.toString();
+
+            sqlString.should.eql("SELECT * FROM users WHERE (`meta`->'$.is_active' = true)");
         });
 
     });

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -33,14 +33,14 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.create({firstName: 'firstName', lastName: 'lastName', password: 'boom!', dateAdded: new Date('1990-01-05T13:30:00Z')});
             Should.exist(sql);
 
-            sql.should.eql(`INSERT INTO users (first_name, last_name, password, date_added) VALUES ('firstName', 'lastName', 'boom!', '1990-01-05 13:30:00.000')`);
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`, `date_added`) VALUES ('firstName', 'lastName', 'boom!', '1990-01-05 13:30:00.000')");
         });
 
         it('Should generate an INSERT statement for a single entry in users table from a VO', function() {
             const sql = mysqlDaoQueryHelper.create(new UserCreateArgs({firstName: 'firstName', lastName: 'lastName', password: 'boom!'}));
             Should.exist(sql);
 
-            sql.should.eql(`INSERT INTO users (first_name, last_name, password) VALUES ('firstName', 'lastName', 'boom!')`);
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('firstName', 'lastName', 'boom!')");
         });
 
         it('Should generate an INSERT statement for a single entry in users table from an object with toJsObj() function defined', function() {
@@ -52,7 +52,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.create(obj);
             Should.exist(sql);
 
-            sql.should.eql(`INSERT INTO users (first_name, last_name, password) VALUES ('firstName', 'lastName', 'boom!')`);
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('firstName', 'lastName', 'boom!')");
         });
 
         it('Should generate an INSERT statement for a single entry in users table from an object with toJSON() function defined', function() {
@@ -64,14 +64,14 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.create(obj);
             Should.exist(sql);
 
-            sql.should.eql(`INSERT INTO users (first_name, last_name, password) VALUES ('Bob', 'Smith', 'another password')`);
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('Bob', 'Smith', 'another password')");
         });
 
         it('Should generate an INSERT statement for a single entry in users table with raw inputs', function() {
             const sql = mysqlDaoQueryHelper.create({firstName: 'firstName', lastName: 'lastName', password: { raw: 'TRIM("   mybadpasswordinput    ")' }, dateAdded: new Date('1990-01-05T13:30:00Z')});
             Should.exist(sql);
 
-            sql.should.eql(`INSERT INTO users (first_name, last_name, password, date_added) VALUES ('firstName', 'lastName', TRIM("   mybadpasswordinput    "), '1990-01-05 13:30:00.000')`);
+            sql.should.eql(`INSERT INTO users (\`first_name\`, \`last_name\`, \`password\`, \`date_added\`) VALUES ('firstName', 'lastName', TRIM("   mybadpasswordinput    "), '1990-01-05 13:30:00.000')`);
         });
 
         it('Should generate an INSERT statement to handle ignoring duplicate keys', function() {
@@ -83,7 +83,7 @@ describe('MysqlDaoQueryHelper', function() {
             }, {ignoreOnDuplicateKey: true});
 
             Should.exist(sql);
-            sql.should.eql(`INSERT INTO users (first_name, last_name, password, date_added) VALUES ('firstName', 'lastName', TRIM("   mybadpasswordinput    "), '1990-01-05 13:30:00.000') ON DUPLICATE KEY UPDATE first_name = first_name`);
+            sql.should.eql(`INSERT INTO users (\`first_name\`, \`last_name\`, \`password\`, \`date_added\`) VALUES ('firstName', 'lastName', TRIM("   mybadpasswordinput    "), '1990-01-05 13:30:00.000') ON DUPLICATE KEY UPDATE first_name = first_name`);
         });
 
     });
@@ -98,7 +98,7 @@ describe('MysqlDaoQueryHelper', function() {
             ]);
             Should.exist(sql);
 
-            sql.should.eql("INSERT INTO users (first_name, last_name, password) VALUES ('firstName', 'lastName', 'boom!'), ('John', 'Doe', 'badpassword'), ('Jane', 'Doe', 'foundrydc')");
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('firstName', 'lastName', 'boom!'), ('John', 'Doe', 'badpassword'), ('Jane', 'Doe', 'foundrydc')");
         });
 
         it('Should generate an INSERT statement to handle ignoring duplicate keys', function() {
@@ -110,7 +110,7 @@ describe('MysqlDaoQueryHelper', function() {
             ], {ignoreOnDuplicateKey: true});
             Should.exist(sql);
 
-            sql.should.eql("INSERT INTO users (first_name, last_name, password) VALUES ('firstName', 'lastName', 'boom!'), ('John', 'Doe', 'badpassword'), ('Jane', 'Doe', 'foundrydc') ON DUPLICATE KEY UPDATE first_name = first_name");
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('firstName', 'lastName', 'boom!'), ('John', 'Doe', 'badpassword'), ('Jane', 'Doe', 'foundrydc') ON DUPLICATE KEY UPDATE first_name = first_name");
         });
 
     });
@@ -120,14 +120,14 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.upsert({firstName: 'firstName', lastName: 'lastName', password: 'boom!'}, {password: 'ka-boom!'});
             Should.exist(sql);
 
-            sql.should.eql("INSERT INTO users (first_name, last_name, password) VALUES ('firstName', 'lastName', 'boom!') ON DUPLICATE KEY UPDATE password = 'ka-boom!'");
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('firstName', 'lastName', 'boom!') ON DUPLICATE KEY UPDATE password = 'ka-boom!'");
         });
 
         it('Should generate an INSERT ... ON DUPLICATE KEY UPDATE statement for raw update args', function() {
             const sql = mysqlDaoQueryHelper.upsert({firstName: 'firstName', lastName: 'lastName', password: 'boom!'}, {password: { raw: 'TRIM("   mybadpasswordinput    ")' } });
             Should.exist(sql);
 
-            sql.should.eql(`INSERT INTO users (first_name, last_name, password) VALUES ('firstName', 'lastName', 'boom!') ON DUPLICATE KEY UPDATE password = TRIM("   mybadpasswordinput    ")`);
+            sql.should.eql(`INSERT INTO users (\`first_name\`, \`last_name\`, \`password\`) VALUES ('firstName', 'lastName', 'boom!') ON DUPLICATE KEY UPDATE password = TRIM("   mybadpasswordinput    ")`);
         });
 
         it('Should generate an INSERT ... ON DUPLICATE KEY UPDATE statement for multiple rows with insert values', function() {
@@ -144,7 +144,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.upsertBulk(insertArgs, updateArgs);
             Should.exist(sql);
 
-            sql.should.eql("INSERT INTO users (first_name, last_name, password) VALUES ('f1', 'l1', 'p1'), ('f2', 'l2', 'p2'), ('f3', 'l3', 'p3') ON DUPLICATE KEY UPDATE first_name = VALUES(first_name), last_name = VALUES(last_name), password = VALUES(password)");
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('f1', 'l1', 'p1'), ('f2', 'l2', 'p2'), ('f3', 'l3', 'p3') ON DUPLICATE KEY UPDATE first_name = VALUES(first_name), last_name = VALUES(last_name), password = VALUES(password)");
         });
 
         it('Should generate an INSERT ... ON DUPLICATE KEY UPDATE statement for multiple rows with specific values', function() {
@@ -161,7 +161,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.upsertBulk(insertArgs, updateArgs);
             Should.exist(sql);
 
-            sql.should.eql("INSERT INTO users (first_name, last_name, password) VALUES ('f1', 'l1', 'p1'), ('f2', 'l2', 'p2'), ('f3', 'l3', 'p3') ON DUPLICATE KEY UPDATE password = 'newpassword1234'");
+            sql.should.eql("INSERT INTO users (`first_name`, `last_name`, `password`) VALUES ('f1', 'l1', 'p1'), ('f2', 'l2', 'p2'), ('f3', 'l3', 'p3') ON DUPLICATE KEY UPDATE password = 'newpassword1234'");
         });
     });
 
@@ -385,21 +385,21 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.updateOne({id: 1}, {email: 'john.doe@gmail.com', firstName: 'john'});
             Should.exist(sql);
 
-            sql.should.eql("UPDATE users SET email = 'john.doe@gmail.com', first_name = 'john' WHERE (id = 1) LIMIT 1");
+            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `first_name` = 'john' WHERE (id = 1) LIMIT 1");
         });
 
         it('Should generate an UPDATE statement and not escape CURRENT_TIMESTAMP', function() {
             const sql = mysqlDaoQueryHelper.updateOne({id: 1}, {email: 'john.doe@gmail.com', dateDeleted: 'CURRENT_TIMESTAMP'});
             Should.exist(sql);
 
-            sql.should.eql("UPDATE users SET email = 'john.doe@gmail.com', date_deleted = CURRENT_TIMESTAMP WHERE (id = 1) LIMIT 1");
+            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `date_deleted` = CURRENT_TIMESTAMP WHERE (id = 1) LIMIT 1");
         });
 
         it('Should work even with ? in WHERE clause for one row', function() {
             const sql = mysqlDaoQueryHelper.updateOne({url: 'http://some.com/?blah=hello'}, {email: 'john.doe@gmail.com', firstName: 'john'});
             Should.exist(sql);
 
-            sql.should.eql("UPDATE users SET email = 'john.doe@gmail.com', first_name = 'john' WHERE (url = 'http://some.com/?blah=hello') LIMIT 1");
+            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `first_name` = 'john' WHERE (url = 'http://some.com/?blah=hello') LIMIT 1");
         });
 
     });
@@ -410,7 +410,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.update({id: 1}, {email: 'john.doe@gmail.com', firstName: 'john', dateUpdated: new Date('2016-09-27T11:30:00Z')});
             Should.exist(sql);
 
-            sql.should.eql("UPDATE users SET email = 'john.doe@gmail.com', first_name = 'john', date_updated = '2016-09-27 11:30:00.000' WHERE (id = 1)");
+            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `first_name` = 'john', `date_updated` = '2016-09-27 11:30:00.000' WHERE (id = 1)");
         })
 
     });

--- a/test/unit/test-mysqlDaoQueryHelper.js
+++ b/test/unit/test-mysqlDaoQueryHelper.js
@@ -171,21 +171,21 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.getOne({firstName: 'John', lastName: 'Doe'});
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (first_name = 'John') AND (last_name = 'Doe') LIMIT 1");
+            sql.should.eql("SELECT * FROM users WHERE (`first_name` = 'John') AND (`last_name` = 'Doe') LIMIT 1");
         });
 
         it('Should allow ? characters in the WHERE clause', function() {
             const sql = mysqlDaoQueryHelper.getOne({url: 'http://www.youtube.com/?q=somevideo'});
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (url = 'http://www.youtube.com/?q=somevideo') LIMIT 1");
+            sql.should.eql("SELECT * FROM users WHERE (`url` = 'http://www.youtube.com/?q=somevideo') LIMIT 1");
         });
 
         it('Should generate an IS NULL in where clause ', function() {
             const sql = mysqlDaoQueryHelper.getOne({firstName: null, lastName: 'Doe'});
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (first_name IS NULL) AND (last_name = 'Doe') LIMIT 1");
+            sql.should.eql("SELECT * FROM users WHERE (`first_name` IS NULL) AND (`last_name` = 'Doe') LIMIT 1");
         });
 
         it('Should generate dates with for a utc timezone ', function() {
@@ -196,7 +196,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.getOne({dateAdded: nowDate});
             Should.exist(sql);
 
-            sql.should.eql(`SELECT * FROM users WHERE (date_added = '${utcDateString}') LIMIT 1`);
+            sql.should.eql(`SELECT * FROM users WHERE (\`date_added\` = '${utcDateString}') LIMIT 1`);
         });
 
         it('Should generate dates with for local timezone ', function() {
@@ -207,7 +207,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = localMysqlDaoQueryHelper.getOne({dateAdded: nowDate});
             Should.exist(sql);
 
-            sql.should.eql(`SELECT * FROM users WHERE (date_added = '${localDateString}') LIMIT 1`);
+            sql.should.eql(`SELECT * FROM users WHERE (\`date_added\` = '${localDateString}') LIMIT 1`);
         });
 
     });
@@ -218,56 +218,56 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.getAll({lastName: 'Doe'});
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (last_name = 'Doe')");
+            sql.should.eql("SELECT * FROM users WHERE (`last_name` = 'Doe')");
         });
 
         it('Should allow ? characters in the WHERE clause', function() {
             const sql = mysqlDaoQueryHelper.getAll({url: 'http://www.youtube.com/?q=somevideo'});
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (url = 'http://www.youtube.com/?q=somevideo')");
+            sql.should.eql("SELECT * FROM users WHERE (`url` = 'http://www.youtube.com/?q=somevideo')");
         });
 
         it('Should allow an array to be passed to WHERE clause', function() {
             const sql = mysqlDaoQueryHelper.getAll({id: [1,2,5,10]});
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (id IN (1,2,5,10))");
+            sql.should.eql("SELECT * FROM users WHERE (`id` IN (1,2,5,10))");
         });
 
         it('Should generate a SELECT statement with a query object and in operator', function() {
             const sql = mysqlDaoQueryHelper.getAll({id: { in: [1,2,3] }});
             Should.exist(sql);
 
-            sql.should.eql('SELECT * FROM users WHERE (id IN (1,2,3))');
+            sql.should.eql('SELECT * FROM users WHERE (`id` IN (1,2,3))');
         });
 
         it('Should generate a SELECT statement with a query object and nin operator', function() {
             const sql = mysqlDaoQueryHelper.getAll({id: { nin: ['apple', 'banana', 'pear'] }});
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (id NOT IN ('apple','banana','pear'))");
+            sql.should.eql("SELECT * FROM users WHERE (`id` NOT IN ('apple','banana','pear'))");
         });
 
         it('Should generate a SELECT statement with a query object and notIn operator', function() {
             const sql = mysqlDaoQueryHelper.getAll({id: { not_in: ['apple', 'banana', 'pear'] }});
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (id NOT IN ('apple','banana','pear'))");
+            sql.should.eql("SELECT * FROM users WHERE (`id` NOT IN ('apple','banana','pear'))");
         });
 
         it('Should generate a SELECT statement with a query object and in/nin operators', function() {
             const sql = mysqlDaoQueryHelper.getAll({id: { in: [7,8,9], nin: [1,2,3] }});
             Should.exist(sql);
 
-            sql.should.eql('SELECT * FROM users WHERE (id IN (7,8,9) AND id NOT IN (1,2,3))');
+            sql.should.eql('SELECT * FROM users WHERE (`id` IN (7,8,9) AND `id` NOT IN (1,2,3))');
         });
 
         it('Should generate a SELECT statement with order by', function() {
             const sql = mysqlDaoQueryHelper.getAll({}, { sort: { firstName: 'ASC', lastName: 'DESC' } });
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users ORDER BY first_name ASC, last_name DESC");
+            sql.should.eql("SELECT * FROM users ORDER BY `first_name` ASC, `last_name` DESC");
         });
 
         it('Should generate a SELECT statement with limit', function() {
@@ -293,7 +293,7 @@ describe('MysqlDaoQueryHelper', function() {
             });
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (date_added >= '1990-01-05 13:30:00.000' AND date_added < '1990-01-10 13:30:00.000')");
+            sql.should.eql("SELECT * FROM users WHERE (`date_added` >= '1990-01-05 13:30:00.000' AND `date_added` < '1990-01-10 13:30:00.000')");
         });
 
         it('Should generate a SELECT statement with a query object and gte/lte', function() {
@@ -305,7 +305,7 @@ describe('MysqlDaoQueryHelper', function() {
             });
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (id >= 5 AND id <= 10)");
+            sql.should.eql("SELECT * FROM users WHERE (`id` >= 5 AND `id` <= 10)");
         });
 
         it('Should generate a SELECT statement with a query object and ne: null', function() {
@@ -316,7 +316,7 @@ describe('MysqlDaoQueryHelper', function() {
             });
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (id IS NOT NULL)");
+            sql.should.eql("SELECT * FROM users WHERE (`id` IS NOT NULL)");
         });
 
         it('Should generate a SELECT statement with multiple query objects', function() {
@@ -340,7 +340,7 @@ describe('MysqlDaoQueryHelper', function() {
             });
             Should.exist(sql);
 
-            sql.should.eql("SELECT * FROM users WHERE (name = 'Chas') AND (last_name != 'Fantastic') AND (id > 2) AND (date_added > '1990-01-05 13:30:00.000' AND date_added <= '1990-01-10 13:30:00.000') AND (lucky_numbers IN (9,17,42))");
+            sql.should.eql("SELECT * FROM users WHERE (`name` = 'Chas') AND (`last_name` != 'Fantastic') AND (`id` > 2) AND (`date_added` > '1990-01-05 13:30:00.000' AND `date_added` <= '1990-01-10 13:30:00.000') AND (`lucky_numbers` IN (9,17,42))");
         });
 
       it('Should generate a SELECT statement with a query object and like: foo%', function() {
@@ -351,7 +351,7 @@ describe('MysqlDaoQueryHelper', function() {
         });
         Should.exist(sql);
 
-        sql.should.eql("SELECT * FROM users WHERE (first_name LIKE 'foo%')");
+        sql.should.eql("SELECT * FROM users WHERE (`first_name` LIKE 'foo%')");
       });
 
     });
@@ -361,21 +361,21 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.getCount({lastName: 'Doe'});
             Should.exist(sql);
 
-            sql.should.eql("SELECT COUNT(*) AS \"count\" FROM users WHERE (last_name = 'Doe')");
+            sql.should.eql("SELECT COUNT(*) AS \"count\" FROM users WHERE (`last_name` = 'Doe')");
         });
 
         it('Should generate a SELECT count(*) statement with limit', function() {
             const sql = mysqlDaoQueryHelper.getCount({lastName: 'Doe'}, { limit: 2 });
             Should.exist(sql);
 
-            sql.should.eql("SELECT COUNT(*) AS \"count\" FROM users WHERE (last_name = 'Doe')");
+            sql.should.eql("SELECT COUNT(*) AS \"count\" FROM users WHERE (`last_name` = 'Doe')");
         });
 
         it('Should generate a SELECT count(*) statement with limit and offset', function() {
             const sql = mysqlDaoQueryHelper.getCount({lastName: 'Doe'}, { offset: 1, limit: 2 });
             Should.exist(sql);
 
-            sql.should.eql("SELECT COUNT(*) AS \"count\" FROM users WHERE (last_name = 'Doe')");
+            sql.should.eql("SELECT COUNT(*) AS \"count\" FROM users WHERE (`last_name` = 'Doe')");
         });
     });
 
@@ -385,21 +385,21 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.updateOne({id: 1}, {email: 'john.doe@gmail.com', firstName: 'john'});
             Should.exist(sql);
 
-            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `first_name` = 'john' WHERE (id = 1) LIMIT 1");
+            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `first_name` = 'john' WHERE (`id` = 1) LIMIT 1");
         });
 
         it('Should generate an UPDATE statement and not escape CURRENT_TIMESTAMP', function() {
             const sql = mysqlDaoQueryHelper.updateOne({id: 1}, {email: 'john.doe@gmail.com', dateDeleted: 'CURRENT_TIMESTAMP'});
             Should.exist(sql);
 
-            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `date_deleted` = CURRENT_TIMESTAMP WHERE (id = 1) LIMIT 1");
+            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `date_deleted` = CURRENT_TIMESTAMP WHERE (`id` = 1) LIMIT 1");
         });
 
         it('Should work even with ? in WHERE clause for one row', function() {
             const sql = mysqlDaoQueryHelper.updateOne({url: 'http://some.com/?blah=hello'}, {email: 'john.doe@gmail.com', firstName: 'john'});
             Should.exist(sql);
 
-            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `first_name` = 'john' WHERE (url = 'http://some.com/?blah=hello') LIMIT 1");
+            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `first_name` = 'john' WHERE (`url` = 'http://some.com/?blah=hello') LIMIT 1");
         });
 
     });
@@ -410,7 +410,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.update({id: 1}, {email: 'john.doe@gmail.com', firstName: 'john', dateUpdated: new Date('2016-09-27T11:30:00Z')});
             Should.exist(sql);
 
-            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `first_name` = 'john', `date_updated` = '2016-09-27 11:30:00.000' WHERE (id = 1)");
+            sql.should.eql("UPDATE users SET `email` = 'john.doe@gmail.com', `first_name` = 'john', `date_updated` = '2016-09-27 11:30:00.000' WHERE (`id` = 1)");
         })
 
     });
@@ -421,14 +421,14 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.deleteOne({id: 1});
             Should.exist(sql);
 
-            sql.should.eql("DELETE FROM users WHERE (id = 1) LIMIT 1");
+            sql.should.eql("DELETE FROM users WHERE (`id` = 1) LIMIT 1");
         });
 
         it('Should generate an DELETE statement even with ? in WHERE clause for one row', function() {
             const sql = mysqlDaoQueryHelper.deleteOne({url: 'http://some.com/?foo=bar'});
             Should.exist(sql);
 
-            sql.should.eql("DELETE FROM users WHERE (url = 'http://some.com/?foo=bar') LIMIT 1");
+            sql.should.eql("DELETE FROM users WHERE (`url` = 'http://some.com/?foo=bar') LIMIT 1");
         });
 
     });
@@ -439,7 +439,7 @@ describe('MysqlDaoQueryHelper', function() {
             const sql = mysqlDaoQueryHelper.delete({age: 30});
             Should.exist(sql);
 
-            sql.should.eql("DELETE FROM users WHERE (age = 30)");
+            sql.should.eql("DELETE FROM users WHERE (`age` = 30)");
         })
 
     });
@@ -672,7 +672,7 @@ describe('MysqlDaoQueryHelper', function() {
 
             const sqlString = sqlObj.toString();
 
-            sqlString.should.eql("SELECT * FROM users WHERE (first_name = 'John') AND (last_name = 'Doe')");
+            sqlString.should.eql("SELECT * FROM users WHERE (`first_name` = 'John') AND (`last_name` = 'Doe')");
         });
 
         it('Should generate good WHERE clause when input contains NULL value', function() {
@@ -682,7 +682,7 @@ describe('MysqlDaoQueryHelper', function() {
 
             const sqlString = sqlObj.toString();
 
-            sqlString.should.eql("SELECT * FROM users WHERE (first_name = 'John') AND (last_name IS NULL)");
+            sqlString.should.eql("SELECT * FROM users WHERE (`first_name` = 'John') AND (`last_name` IS NULL)");
         });
 
         it('Should generate good WHERE clause when input contains undefined value (assumes it means NULL)', function() {
@@ -693,7 +693,7 @@ describe('MysqlDaoQueryHelper', function() {
 
             const sqlString = sqlObj.toString();
 
-            sqlString.should.eql("SELECT * FROM users WHERE (first_name = 'John') AND (last_name IS NULL)");
+            sqlString.should.eql("SELECT * FROM users WHERE (`first_name` = 'John') AND (`last_name` IS NULL)");
         });
 
         it('Should generate good WHERE clause when input contains special functions', function() {
@@ -704,7 +704,7 @@ describe('MysqlDaoQueryHelper', function() {
 
             const sqlString = sqlObj.toString();
 
-            sqlString.should.eql("SELECT * FROM users WHERE (date_created = CURRENT_TIMESTAMP) AND (date_updated = NOW()) AND (email IS NULL) AND (first_name IS NOT NULL)");
+            sqlString.should.eql("SELECT * FROM users WHERE (`date_created` = CURRENT_TIMESTAMP) AND (`date_updated` = NOW()) AND (`email` IS NULL) AND (`first_name` IS NOT NULL)");
         });
 
         it('Should generate good WHERE clause when input contains JSON path query', function() {


### PR DESCRIPTION
This is a change to always quote column identifiers to guard against reserved keyword conflicts. Ideally, this shouldn't be an issue, but I think automatic backtick quoting is a sane default since it's harmless. Squel provides an `autoQuoteFieldNames` option to handle most of the column quoting, but some manual quoting had to be added for custom WHERE, ORDER BY, and ON UPDATE expressions.